### PR TITLE
set state.height to always return even #

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,8 +77,9 @@ export default class Headroom extends Component {
   }
 
   setHeightOffset = () => {
+    const h = this.refs.inner.offsetHeight
     this.setState({
-      height: this.refs.inner.offsetHeight,
+      height: h % 2 === 0 ? h : h-1,
     })
   }
 


### PR DESCRIPTION
hm, not able to get the makefile to work on my system for some reason, so made changes in my project `node_modules/react-headroom`

addressing #92:

re: your point about retina, i'm on a 4k display and i see the white-line--what makes you think it's just non-retina?

this change is a bandaid, just catching odd-# heights and knocking them down a pixel

which, while it does fix the white-line issue, effectively overrides the user's inputted height--so not optimal.  your call as to whether or not this temp bandaid is acceptable for this glitch, np if you don't accept the pr

i'll try to spend some time trying to grok the logic elsewhere in the component & figure the root of the problem, but won't be soon i fear
